### PR TITLE
Add basic executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ echo $image;
 
 
 ```bash
-$ php -f http://drop.caffeina.co/image/160L0Y3C0a29/vocaloid.jpg -r .25 -w 0.25 -i
+$ php pixel.php -f http://drop.caffeina.co/image/160L0Y3C0a29/vocaloid.jpg -r .25 -w 0.25 -i
 ```
 
 <img src="http://drop.caffeina.co/image/1B133A0N3V0c/vocal.png" width="700" />

--- a/bin/pixeler
+++ b/bin/pixeler
@@ -1,0 +1,24 @@
+#!/usr/bin/env php
+<?php
+
+// Include autoloader
+require __DIR__.'/../../../autoload.php';
+
+// Parse options from command line
+$opts = array_merge([
+    'f' => false,
+    'r' => 1.0,  // Resize factor 1.0 = 100%
+    'w' => 0.75, // Dither treshold weight
+], getopt("f:r:w:ib"));
+
+// An image file/url is required.
+$opts['f'] || die("Must specify an image file.\n");
+
+// The -i option inverts the image
+$image = Pixeler\Pixeler::image($opts['f'], $opts['r'], isset($opts['i']), $opts['w']);
+
+// No colors if "-b" is passed
+isset($opts['b']) && $image->clearColors();
+
+// The Pixeler\Image instance render itself if casted to a string
+echo $image;

--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,6 @@
     "minimum-stability": "dev",
     "autoload": {
         "psr-4": { "Pixeler\\" : "" }
-    }
+    },
+    "bin": ["bin/pixeler"]
 }


### PR DESCRIPTION
This commit adds the example `pixel.php` as `vendor/bin/pixeler`. To use it the recommended method would be to run `composer global require 'lastguest/pixeler' 'dev-master'` then add `$HOME/.composer/vendor/bin/` to `$PATH`. Users could then run `pixeler -f file.jpg -w 0.4` etc from anywhere.

Also fixes minor mistake in README example
