### PR TITLE
Remove wildcard version constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Render images in CLI with UTF-8 characters.
 Require in your project with [composer](https://getcomposer.org/download/) :
 
 ```bash
-$ composer require lastguest/pixeler:"*"
+$ composer require lastguest/pixeler
 ```
 
 This will also install a **pixeler** tool in : 


### PR DESCRIPTION
Not needed, Composer will fill in automatically the latest version (`~1.0.0`) when called without passing one. Plus wildcard is bad practice anyway so :p
