### PR TITLE
add gd extension as requirement in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         }
     ],
     "require": {
-        "php": ">=5.4"
+        "php": ">=5.4",
+        "ext-gd": "*"
     },
     "config": {
         "preferred-install": "dist"


### PR DESCRIPTION
The following error is returned when GD extension is not installed:

```
PHP Fatal error:  Uncaught Exception: Image format not supported. in /home/jawira/PhpstormProjects/poc-cli-libraries/vendor/lastguest/pixeler/src/Pixeler/Image.php:26
```

This message is not correct since the real problem is the lack of GD extensions.
Adding GD as a requirement in composer.json will solve this.